### PR TITLE
Add datasetLabel to BarClass object

### DIFF
--- a/src/Chart.StackedBar.js
+++ b/src/Chart.StackedBar.js
@@ -146,6 +146,7 @@
 						datasetObject.bars.push(new this.BarClass({
 							value : dataPoint,
 							label : data.labels[index],
+							datasetLabel: dataset.label,
 							strokeColor : dataset.strokeColor,
 							fillColor : dataset.fillColor,
 							highlightFill : dataset.highlightFill || dataset.fillColor,


### PR DESCRIPTION
The datasetLabel attribute exists in the regular Bar but is missing from StackedBar.
