### PR TITLE
Correct bar width for stacked bar

### DIFF
--- a/src/Chart.StackedBar.js
+++ b/src/Chart.StackedBar.js
@@ -44,12 +44,7 @@
 			this.ScaleClass = Chart.Scale.extend({
 				offsetGridLines : true,
 				calculateBarX : function(datasetCount, datasetIndex, barIndex){
-					//Reusable method for calculating the xPosition of a given bar based on datasetIndex & width of the bar
-					var xWidth = this.calculateBaseWidth(),
-						xAbsolute = this.calculateX(barIndex) - (xWidth/2),
-						barWidth = this.calculateBarWidth(datasetCount);
-
-					return xAbsolute + barWidth;
+					return this.calculateX(barIndex);
 				},
 				calculateBarY : function(datasets, dsIndex, barIndex, value){
 					var offset = 0,
@@ -80,9 +75,7 @@
 				},
 				calculateBarWidth : function(datasetCount){
 					//The padding between datasets is to the right of each bar, providing that there are more than 1 dataset
-					var baseWidth = this.calculateBaseWidth();
-
-					return (baseWidth / (datasetCount - 1));
+					return this.calculateBaseWidth();
 				},
 				calculateBarHeight : function(datasets, dsIndex, barIndex, value) {
 					var sum = 0;


### PR DESCRIPTION
Since a stacked bar is displayed as a single vertical bar with segments representing the different datasets, the width of each bar corresponds to the entire bar width available and does not depend on the number of datasets. The x-coordinate of the bar is at the beginning of the section available for that bar.

Currently, with multiple datasets, the bar is not given its full width. The changes to the code are an attempt to fix that bug.
