### PR TITLE
Breaks when data is an array of integers as strings.

### DIFF
--- a/src/Chart.StackedBar.js
+++ b/src/Chart.StackedBar.js
@@ -65,7 +65,7 @@
 						if(i === dsIndex && value) {
 							offset += value;
 						} else {
-							offset += datasets[i].bars[barIndex].value;
+							offset = +offset + +datasets[i].bars[barIndex].value;
 						}
 					}
 
@@ -376,7 +376,7 @@
 						if(self.options.relativeBars) {
 							values[barIndex] = 100;
 						} else {
-							values[barIndex] += bar.value;
+							values[barIndex] = +values[barIndex] + +bar.value;
 						}
 					});
 				});


### PR DESCRIPTION
'+=' can only append strings so specifying each variable as ints with
'+' fixes this.