### PR TITLE
Fixed 'main' path in bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/nnnick/Chart.js",
   "author": "Regaddi",
   "main": [
-    "Chart.StackedBar.js"
+    "src/Chart.StackedBar.js"
   ],
   "dependencies": {
     "Chart.js": ">= 1.0.0-beta"


### PR DESCRIPTION
This allows tools like [grunt-wiredep](https://github.com/stephenplusplus/grunt-wiredep) to find the Chart.StackedBar.js file.