### PR TITLE
Introduce |tooltipHideZero| flag

### DIFF
--- a/docs/Stacked-Bar-Chart.md
+++ b/docs/Stacked-Bar-Chart.md
@@ -73,8 +73,11 @@ These are the customisation options specific to StackedBar charts. These options
 
 	{% raw %}
 	//String - A legend template
-	legendTemplate : "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<datasets.length; i++){%><li><span style=\"background-color:<%=datasets[i].lineColor%>\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>"
+	legendTemplate : "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<datasets.length; i++){%><li><span style=\"background-color:<%=datasets[i].lineColor%>\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>",
 	{% endraw %}
+	
+	//Boolean - Hide labels with value set to 0
+	tooltipHideZero: false
 }
 ```
 

--- a/src/Chart.StackedBar.js
+++ b/src/Chart.StackedBar.js
@@ -55,7 +55,10 @@
 		totalColor: '#fff',
 
 		//String - Total Label
-		totalLabel: 'Total'
+		totalLabel: 'Total',
+
+		//Boolean - Hide labels with value set to 0
+		tooltipHideZero: false
 	};
 
 	Chart.Type.extend({
@@ -263,6 +266,10 @@
 						};
 
 						helpers.each(Elements, function(element) {
+							if (this.options.tooltipHideZero && element.value === 0) {
+								return;
+							}
+
 							xPositions.push(element.x);
 							yPositions.push(element.y);
 


### PR DESCRIPTION
Improves readability for sparse data - lots of labels but many with 0 as value.