### PR TITLE
Fix missing datasetLabel

### DIFF
--- a/src/Chart.StackedBar.js
+++ b/src/Chart.StackedBar.js
@@ -492,6 +492,7 @@
 					this.datasets[datasetIndex].bars.push(new this.BarClass({
 						value : helpers.isNumber(value)?value:0,
 						label : label,
+						datasetLabel : this.datasets[datasetIndex].label,
 						x: this.scale.calculateBarX(this.scale.valuesCount+1),
 						y: this.scale.endPoint,
 						width : this.scale.calculateBarWidth(this.datasets.length),


### PR DESCRIPTION
When using addData method, the datasetLabel is missing.  This ensures it is avail.
