### PR TITLE
Add the `relativeValue` variable to the `multiTooltipTemplate` for `relativeBars` charts

### DIFF
--- a/samples/relative-stacked-bar.html
+++ b/samples/relative-stacked-bar.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Stacked Bar Chart</title>
+		<script src="http://www.chartjs.org/assets/Chart.min.js"></script>
+		<script src="../src/Chart.StackedBar.js"></script>
+		<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	</head>
+	<body>
+		<div style="width: 50%">
+			<canvas id="canvas" height="450" width="600"></canvas>
+		</div>
+
+		<button id="randomizeData">Randomize Data</button>
+
+	<script>
+	var randomScalingFactor = function(){ return Math.round(Math.random()*100)};
+	var randomColorFactor = function(){ return Math.round(Math.random()*255)};
+
+	var barChartData = {
+		labels : ["January","February","March","April","May","June","July"],
+		datasets : [
+			{
+				fillColor : "rgba(220,220,220,0.5)",
+				strokeColor : "rgba(220,220,220,0.8)",
+				highlightFill: "rgba(220,220,220,0.75)",
+				highlightStroke: "rgba(220,220,220,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			},
+			{
+				fillColor : "rgba(151,187,205,0.5)",
+				strokeColor : "rgba(151,187,205,0.8)",
+				highlightFill : "rgba(151,187,205,0.75)",
+				highlightStroke : "rgba(151,187,205,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			},
+			{
+				fillColor : "rgba(240,73,73,0.5)",
+				strokeColor : "rgba(240,73,73,0.8)",
+				highlightFill : "rgba(240,73,73,0.75)",
+				highlightStroke : "rgba(240,73,73,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			}
+		]
+	};
+	window.onload = function(){
+		var ctx = document.getElementById("canvas").getContext("2d");
+		window.myBar = new Chart(ctx).StackedBar(barChartData, {
+			multiTooltipTemplate: "<%= value %> represents <%= Math.round(relativeValue) %>% of the x axis",
+			relativeBars: true,
+			showTotal: true,
+			responsive : true
+		});
+
+		$('#randomizeData').click(function(){
+			barChartData.datasets[0].fillColor = 'rgba(' + randomColorFactor() + ',' + randomColorFactor() + ',' + randomColorFactor() + ',.7)';
+			barChartData.datasets[0].data = [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()];
+
+			barChartData.datasets[1].fillColor = 'rgba(' + randomColorFactor() + ',' + randomColorFactor() + ',' + randomColorFactor() + ',.7)';
+			barChartData.datasets[1].data = [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()];
+
+			window.myBar.update();
+		});
+	};
+	</script>
+	</body>
+</html>

--- a/src/Chart.StackedBar.js
+++ b/src/Chart.StackedBar.js
@@ -262,12 +262,22 @@
 							}
 						});
 
+						// Calculates the total of the bar, summing all elements values.
+						// It will be used when `showTotal` is `true`.
+						// It also will be useful for building template legends
+						// when `relativeBars` is `true`.
+						var sumOfValues = 0
+						helpers.each(Elements, function(element) { sumOfValues += element.value; });
+
 						var total = {
 							datasetLabel: this.options.totalLabel,
-							value: 0,
+							value: sumOfValues,
 							fillColor: this.options.totalColor,
 							strokeColor: this.options.totalColor
 						};
+
+						// Fill the `relativeValue` variable for relative charts
+						if (this.options.relativeBars) { total.relativeValue = 100 }
 
 						helpers.each(Elements, function(element) {
 							if (this.options.tooltipHideZero && element.value === 0) {
@@ -277,9 +287,17 @@
 							xPositions.push(element.x);
 							yPositions.push(element.y);
 
-							total.value += element.value;
+							// Include `relativeValue` variable to the element if `relativeBars` is enabled.
+							if (this.options.relativeBars) {
+								if (total.value == 0 || element.value == 0) {
+									element.relativeValue = 0
+								} else {
+									// We're not rouding up the percentage so it can be formatted
+									// with as much as decimal places as needed in the `multiTooltipTemplate`.
+									element.relativeValue = element.value / total.value * 100
+								}
+							}
 
-							//Include any colour information about the element
 							tooltipLabels.push(helpers.template(this.options.multiTooltipTemplate, element));
 							tooltipColors.push({
 								fill: element._saved.fillColor || element.fillColor,


### PR DESCRIPTION
When specifying the `multiTooltipTemplate` variable for charts with
`relativeBars` set to `true`, it is possible to use the `relativeValue`,
which is a floating point that represents the value of the x axys.

Usage:

```
new Chart(ctx).StackedBar(barChartData, {
  multiTooltipTemplate: "<%= value %> represents <%= Math.round(relativeValue) %>% of the x axis",
  relativeBars: true,
  showTotal: true // also works with `showTotal: false`
});
```

This is the added sample file result:

<img width="857" alt="screen shot 2015-10-26 at 12 05 30" src="https://cloud.githubusercontent.com/assets/38432/10730887/ddb0fba2-7bd9-11e5-8142-bdd15a7ea938.png">
