### PR TITLE
Add xLabels to the docs on chart options

### DIFF
--- a/docs/Stacked-Bar-Chart.md
+++ b/docs/Stacked-Bar-Chart.md
@@ -77,7 +77,10 @@ These are the customisation options specific to StackedBar charts. These options
 	{% endraw %}
 	
 	//Boolean - Hide labels with value set to 0
-	tooltipHideZero: false
+	tooltipHideZero: false,
+	
+	//Array - Labels that are rendered on the x axis, defaults to labels in data
+	xLabels: ["January", "February", "March", "April", "May", "June", "July"]
 }
 ```
 


### PR DESCRIPTION
There is an undocumented (and very helpful) option to override the values on the x axis that is not a standard option. This change will add it to the documentation.